### PR TITLE
Fix closing of <abbr>. Replaced </span> with </abbr>

### DIFF
--- a/ffbot.py
+++ b/ffbot.py
@@ -173,7 +173,7 @@ def main(catname, pagename, what, templates, table):
         
         entry = ''
         if len(rev['reason']) != 0:
-            entry += '<abbr style="color: #999; " title="Begrunnelse i mal">B:</span> %s<br />' % rev['reason']
+            entry += '<abbr style="color: #999; " title="Begrunnelse i mal">B:</abbr> %s<br />' % rev['reason']
         if len(rev['comment']) != 0:
             entry += '<abbr style="color: #999; " title="Redigeringsforklaring">R:</abbr> <nowiki>%s</nowiki><br />' % rev['comment']
         entry += "<small>''%s av [[Bruker:%s|%s]] den %s''</small>" % (link, rev['user'], rev['user'], rev['date'].strftime('%e. %B %Y'))


### PR DESCRIPTION
Hi. Could you please add this commit? It fixes some linterrors on https://no.wikipedia.org/w/index.php?title=Spesial:LintErrors/missing-end-tag&dir=prev&offset=777612